### PR TITLE
[WIP] fix-move-iface-rename-to-ansible

### DIFF
--- a/build.json
+++ b/build.json
@@ -22,8 +22,7 @@
       "sudo yum install -y epel-release",
       "sudo yum install -y ansible git vim bash-completion",
       "sudo yum install -y NetworkManager",
-      "sudo systemctl restart NetworkManager",
-      "sudo nmcli con mod 'Wired connection 1' connection.id 'eth1'"
+      "sudo systemctl restart NetworkManager"
     ]
    },
 


### PR DESCRIPTION
Delete priv iface naming to move it to ansible.
 
**NOTE:** It requires merge of the PR [#115](https://github.com/jprorama/CRI_XCBC/pull/115) in CRI-XCBC submodule project.