### PR TITLE
Use site-build.yaml playbook that contains build roles.

### DIFF
--- a/compute-openstack.json
+++ b/compute-openstack.json
@@ -27,7 +27,7 @@
       },
       {
          "type": "ansible-local",
-         "playbook_file": "CRI_XCBC/site.yaml",
+         "playbook_file": "CRI_XCBC/site-build.yaml",
          "playbook_dir": "CRI_XCBC",
          "inventory_groups": "compute",
          "extra_arguments": [ "-b" ]


### PR DESCRIPTION
This PR proposes a fix to use the site-build.yaml playbook that contains build roles to build a compute image. Otherwise, it would fail because it runs compute.yml from site.yaml instead of compute-build.yml from site-build.yaml. We adopted site-build.yaml and site-ops.yaml convention to accommodate for ansible roles run during packer build and terraform deploy stages
