### PR TITLE
Patch fix vars in build file

### DIFF
--- a/build.json
+++ b/build.json
@@ -5,7 +5,7 @@
 	  "networks": [ "{{ user `external-net` }}","{{ user `internal-net` }}"], 
 	  "instance_floating_ip_net": "{{ user `external-net` }}",
 	  "instance_name": "{{ user `build_instance_name` }}",
-	  "image_name": "{{ user `build_instance_name` }}-V{{user `img_build_version`}}",
+	  "image_name": "{{ user `build_instance_name` }}-V{{user `build_version`}}",
 	  "ssh_username": "{{ user `ssh_username` }}",
 	  "ssh_keypair_name": "{{ user `ssh_keypair_name` }}",
 	  "ssh_private_key_file": "{{ user `private_key_file-path` }}",

--- a/build.json
+++ b/build.json
@@ -8,8 +8,8 @@
 	  "image_name": "{{ user `build_instance_name` }}-V{{user `build_version`}}",
 	  "ssh_username": "{{ user `ssh_username` }}",
 	  "ssh_keypair_name": "{{ user `ssh_keypair_name` }}",
-	  "ssh_private_key_file": "{{ user `private_key_file-path` }}",
-	  "ssh_host": "{{ user `ssh_host-IP` }}",
+	  "ssh_private_key_file": "{{ user `private_key_file` }}",
+	  "ssh_host": "{{ user `ssh_host` }}",
 	  "reuse_ips": true,
 	  "flavor": "{{ user `flavor` }}"
   }],

--- a/build.json
+++ b/build.json
@@ -2,8 +2,8 @@
   "builders": [{
 	  "type": "openstack",
 	  "source_image_name": "{{ user `source_image_name` }}",
-	  "networks": [ "{{ user `external-net-ID` }}","{{ user `internal-net-ID` }}"], 
-	  "instance_floating_ip_net": "{{ user `external-net-ID` }}",
+	  "networks": [ "{{ user `external-net` }}","{{ user `internal-net` }}"], 
+	  "instance_floating_ip_net": "{{ user `external-net` }}",
 	  "instance_name": "{{ user `build_instance_name` }}",
 	  "image_name": "{{ user `build_instance_name` }}-V{{user `img_build_version`}}",
 	  "ssh_username": "{{ user `ssh_username` }}",

--- a/compute-openstack.json
+++ b/compute-openstack.json
@@ -27,7 +27,7 @@
       },
       {
          "type": "ansible-local",
-         "playbook_file": "CRI_XCBC/site.yaml",
+         "playbook_file": "CRI_XCBC/site-build.yaml",
          "playbook_dir": "CRI_XCBC",
          "inventory_groups": "compute",
          "extra_arguments": [ "-b" ]


### PR DESCRIPTION
This PR fixes the inconsistent variable naming in the build.json file to match the variable names used in the gen-vars.py script which is used to generate the vars.json